### PR TITLE
Fixed log parser for Unifi version 4.3.28.11361

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ rule "parse Ubiquity access point logs"
 when
   has_field("message")
 then
-  let m = regex("^\\(?\"?.+,(.+?),.+\"?\\)? (.+?): (.+)$", to_string($message.message));
+  let m = regex("^.+,(.+?),.+: (.+): (\\{.+\\})(.+$|$)", to_string($message.message));
   
   let bssid = m["0"];
   let subsystem = m["1"];


### PR DESCRIPTION
Log parser was tested against Unifi AP with software version 4.3.28.11361 in my personal environment.

Screenshot with log output below:

<img width="1587" alt="Screenshot 2021-08-07 at 22 02 45" src="https://user-images.githubusercontent.com/14159694/128612582-d51115b2-a7b6-49b2-9067-729b5e31d310.png">

Closes #5 